### PR TITLE
feat: add client-only homepage

### DIFF
--- a/dynastyhub-home-rebuild/code/app.js
+++ b/dynastyhub-home-rebuild/code/app.js
@@ -1,0 +1,100 @@
+async function loadJSON(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`Failed to load ${path}`);
+  return await res.json();
+}
+
+function pct(v) {
+  if (v == null) return '—';
+  const n = Number(v);
+  return Number.isFinite(n) ? `${n.toFixed(1)}%` : v;
+}
+
+function statCard(title, value) {
+  return `<div class="stat-card"><div class="stat-title">${title}</div><div class="stat-value">${pct(value)}</div></div>`;
+}
+
+function renderTable(el, data) {
+  if (!data || !data.length) {
+    el.innerHTML = '<div class="empty">No table data</div>';
+    return;
+  }
+  const row = data[0];
+  const order = ["POS", "NFL", "AGE", "HT", "WT", "FILM GRADE", "OVR GRADE"];
+  el.innerHTML = `<div class="mini-table">${order.map(k => `<div class="cell">${row[k] || ''}</div>`).join('')}</div>`;
+}
+
+async function renderPlot(id, payload) {
+  if (payload && payload.data && payload.layout) {
+    await Plotly.newPlot(id, payload.data, payload.layout, { displayModeBar: false, responsive: true });
+  } else {
+    const el = document.getElementById(id);
+    el.innerHTML = '<div class="empty">No chart data</div>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const [prospects, embeds] = await Promise.all([
+    loadJSON('../data/prospects.json'),
+    loadJSON('../data/embeds.json')
+  ]);
+
+  const iframeIds = {
+    SYOP_COLUMN_CHART: 'embedSyop',
+    POSITION_AVERAGE_GAUGES: 'embedGauges',
+    CHAMPIONSHIP_OWNERSHIP_BAR: 'embedChampionship',
+    TOP60_POSITIONAL_DISTRIBUTION_LINE: 'embedTop60',
+    FLEX_TOP20_SCATTER: 'embedFlex',
+    ALL_POS_PPR_SCATTER: 'embedAllPos',
+    HIT_RATE_BY_ROUND_INFOGRAPHIC: 'embedHitRate'
+  };
+  Object.entries(iframeIds).forEach(([key, id]) => {
+    if (embeds[key]) document.getElementById(id).src = embeds[key];
+  });
+
+  let index = 0;
+  const chipsEl = document.getElementById('chips');
+  const tableEl = document.getElementById('miniTable');
+  const statsEl = document.getElementById('statsRow');
+
+  function renderChips() {
+    chipsEl.innerHTML = prospects.map((p, i) => `<button class="chip ${i === index ? 'active' : ''}" data-index="${i}">${p.name}</button>`).join('');
+    chipsEl.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        index = Number(btn.dataset.index);
+        update();
+      });
+    });
+  }
+
+  function renderStats(player) {
+    const s = player.stats || {};
+    const label3 = player.metric3LabelFull || (player.metric3Label === 'RRG' ? 'ROUTE RUNNING GRADE' : 'ELUSIVENESS GRADE');
+    statsEl.innerHTML = [
+      statCard('PRODUCTION GRADE', s.production),
+      statCard('EFFICIENCY GRADE', s.efficiency),
+      statCard(label3, s.metric3),
+      statCard('ATHLETICISM GRADE', s.athleticism)
+    ].join('');
+  }
+
+  async function update() {
+    const player = prospects[index];
+    renderChips();
+    renderTable(tableEl, player.table);
+    renderStats(player);
+    await renderPlot('radar', player.radar);
+    await renderPlot('spark', player.sparkline);
+  }
+
+  document.getElementById('prevBtn').addEventListener('click', () => {
+    index = (index - 1 + prospects.length) % prospects.length;
+    update();
+  });
+  document.getElementById('nextBtn').addEventListener('click', () => {
+    index = (index + 1) % prospects.length;
+    update();
+  });
+
+  update();
+});

--- a/dynastyhub-home-rebuild/code/index.html
+++ b/dynastyhub-home-rebuild/code/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dynasty Hub — Home</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@600;700&family=Bruno+Ace&family=Syncopate:wght@400;700&family=DM+Sans:wght@400;500;700&family=Quicksand:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./styles.css" />
+  <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+</head>
+<body>
+  <noscript>Enable JavaScript.</noscript>
+  <div id="app">
+    <aside class="sidebar"></aside>
+    <main class="main">
+      <header class="header"><h1>Dynasty Hub</h1></header>
+      <div class="top-row">
+        <div class="panel prospects">
+          <div class="panel-header">
+            <h2>Top Rookie Prospects</h2>
+            <div class="nav-buttons">
+              <button id="prevBtn" class="nav-btn">Previous</button>
+              <button id="nextBtn" class="nav-btn">Next</button>
+            </div>
+          </div>
+          <div class="chips" id="chips"></div>
+          <div class="mini-grid">
+            <div id="miniTable"></div>
+            <div id="radar" class="chart"></div>
+          </div>
+          <div id="statsRow" class="stats-row"></div>
+          <div id="spark" class="chart spark"></div>
+        </div>
+        <div class="panel analytics">
+          <div class="panel-header"><h2>Career Length Analytics</h2></div>
+          <div class="embed-stack">
+            <iframe id="embedSyop" class="embed" loading="lazy"></iframe>
+            <iframe id="embedGauges" class="embed" loading="lazy"></iframe>
+          </div>
+        </div>
+      </div>
+      <div class="middle-grid">
+        <div class="panel"><iframe id="embedChampionship" class="embed" loading="lazy"></iframe></div>
+        <div class="panel"><iframe id="embedTop60" class="embed" loading="lazy"></iframe></div>
+        <div class="panel"><iframe id="embedFlex" class="embed" loading="lazy"></iframe></div>
+        <div class="panel"><iframe id="embedAllPos" class="embed" loading="lazy"></iframe></div>
+      </div>
+      <div class="panel full"><iframe id="embedHitRate" class="embed" loading="lazy"></iframe></div>
+    </main>
+  </div>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/dynastyhub-home-rebuild/code/styles.css
+++ b/dynastyhub-home-rebuild/code/styles.css
@@ -1,0 +1,205 @@
+:root {
+  --color-canvas: #141a32;
+  --color-surface: #1a1e35;
+  --color-surface-secondary: #2c334f;
+  --color-text: #efefef;
+  --color-muted: #b7bddc;
+  --color-accent: #7300ff;
+  --color-info: #6bb0ff;
+  --color-success: #6affd0;
+  --color-danger: #ff0266;
+
+  --radius-panel: 12px;
+  --radius-chip: 14px;
+  --radius-button: 18px;
+
+  --font-heading: 'Orbitron', sans-serif;
+  --font-display: 'Bruno Ace', sans-serif;
+  --font-mono: 'Syncopate', sans-serif;
+  --font-body: 'DM Sans', 'Quicksand', sans-serif;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-body);
+}
+#app {
+  display: flex;
+  min-height: 100vh;
+}
+.sidebar {
+  width: 60px;
+  background: var(--color-surface-secondary);
+}
+.main {
+  flex: 1;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.header h1 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 24px;
+}
+.top-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.middle-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+.panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-surface-secondary);
+  border-radius: var(--radius-panel);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+}
+.panel.full {
+  margin-top: 16px;
+}
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.panel-header h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 18px;
+  font-weight: 600;
+}
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.chip {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-surface-secondary);
+  border-radius: var(--radius-chip);
+  padding: 6px 12px;
+  color: var(--color-muted);
+  font-family: var(--font-body);
+  font-weight: 600;
+  cursor: pointer;
+}
+.chip:hover,
+.chip.active {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+  box-shadow: 0 0 0 1px var(--color-accent) inset;
+}
+.chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+.mini-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.mini-table {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 4px;
+  background: var(--color-canvas);
+  border: 1px solid var(--color-surface-secondary);
+  border-radius: 9px;
+  padding: 8px;
+  font-family: var(--font-heading);
+  font-size: 12px;
+}
+.mini-table .cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 4px;
+}
+.chart {
+  background: var(--color-canvas);
+  border: 1px dashed var(--color-surface-secondary);
+  border-radius: var(--radius-panel);
+  min-height: 260px;
+}
+.chart.spark {
+  min-height: 140px;
+}
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin: 10px 0;
+}
+.stat-card {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-surface-secondary);
+  border-radius: var(--radius-panel);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.stat-title {
+  font: 700 10px var(--font-body);
+  color: var(--color-muted);
+  letter-spacing: .03em;
+}
+.stat-value {
+  font: 800 18px var(--font-display);
+  color: var(--color-success);
+}
+.nav-buttons {
+  display: flex;
+  gap: 8px;
+}
+.nav-btn {
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-muted);
+  border-radius: var(--radius-button);
+  padding: 6px 12px;
+  color: var(--color-text);
+  cursor: pointer;
+  font-family: var(--font-body);
+}
+.nav-btn:hover {
+  border-color: var(--color-accent);
+}
+.nav-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+}
+.embed {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: var(--radius-panel);
+}
+.embed-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+}
+.middle-grid .panel {
+  height: 300px;
+}
+.panel.full .embed {
+  height: 400px;
+}
+
+@media (max-width: 1100px) {
+  .top-row,
+  .middle-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- recreate homepage layout with sidebar, header, prospects panel and embedded analytics
- render player chips with table, radar, sparkline and stats from JSON
- add styling using design tokens and wire up external chart iframes

## Testing
- `node --check code/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf05f73044832eac7a5050cee494f6