### PR TITLE
feat: add client-only homepage

### DIFF
--- a/dynastyhub-home-rebuild/code/app.js
+++ b/dynastyhub-home-rebuild/code/app.js
@@ -1,0 +1,79 @@
+async function init() {
+  const [prospects, embeds] = await Promise.all([
+    fetch('../data/prospects.json').then(r => r.json()),
+    fetch('../data/embeds.json').then(r => r.json())
+  ]);
+
+  const chipsContainer = document.getElementById('player-chips');
+  let current = 0;
+
+  function renderChips() {
+    chipsContainer.innerHTML = '';
+    prospects.forEach((player, idx) => {
+      const chip = document.createElement('button');
+      chip.className = 'chip';
+      chip.textContent = player.name;
+      chip.addEventListener('click', () => {
+        current = idx;
+        update();
+      });
+      chipsContainer.appendChild(chip);
+    });
+  }
+
+  function update() {
+    [...chipsContainer.children].forEach((chip, idx) => {
+      chip.classList.toggle('active', idx === current);
+    });
+
+    const player = prospects[current];
+
+    const tableContainer = document.getElementById('mini-table');
+    tableContainer.innerHTML = '';
+    const table = document.createElement('table');
+    const row = document.createElement('tr');
+    Object.values(player.table[0]).forEach(html => {
+      const td = document.createElement('td');
+      td.innerHTML = html;
+      row.appendChild(td);
+    });
+    table.appendChild(row);
+    tableContainer.appendChild(table);
+
+    Plotly.react('radar', player.radar.data, player.radar.layout);
+    Plotly.react('sparkline', player.sparkline.data, player.sparkline.layout);
+
+    document.getElementById('stat-production').textContent = format(player.stats.production);
+    document.getElementById('stat-efficiency').textContent = format(player.stats.efficiency);
+    document.getElementById('stat-metric3').textContent = format(player.stats.metric3);
+    document.getElementById('stat-athleticism').textContent = format(player.stats.athleticism);
+    document.getElementById('stat-metric3-title').textContent = player.metric3LabelFull;
+  }
+
+  function format(num) {
+    return num.toFixed(1) + '%';
+  }
+
+  document.getElementById('prev').addEventListener('click', () => {
+    current = (current - 1 + prospects.length) % prospects.length;
+    update();
+  });
+
+  document.getElementById('next').addEventListener('click', () => {
+    current = (current + 1) % prospects.length;
+    update();
+  });
+
+  document.getElementById('embed-syop').src = embeds.SYOP_COLUMN_CHART;
+  document.getElementById('embed-gauges').src = embeds.POSITION_AVERAGE_GAUGES;
+  document.getElementById('embed-ownership').src = embeds.CHAMPIONSHIP_OWNERSHIP_BAR;
+  document.getElementById('embed-top60').src = embeds.TOP60_POSITIONAL_DISTRIBUTION_LINE;
+  document.getElementById('embed-flex').src = embeds.FLEX_TOP20_SCATTER;
+  document.getElementById('embed-ppr').src = embeds.ALL_POS_PPR_SCATTER;
+  document.getElementById('embed-hit-rate').src = embeds.HIT_RATE_BY_ROUND_INFOGRAPHIC;
+
+  renderChips();
+  update();
+}
+
+init();

--- a/dynastyhub-home-rebuild/code/index.html
+++ b/dynastyhub-home-rebuild/code/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dynasty Hub Home</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600&family=Bruno+Ace&family=Syncopate:wght@400;700&family=DM+Sans:wght@400;500;700&family=Quicksand:wght@400;500;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.plot.ly/plotly-2.24.1.min.js"></script>
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <h1 class="logo">DH</h1>
+    </aside>
+    <main class="main">
+      <header class="header">
+        <h2>Dynasty Hub</h2>
+      </header>
+      <div class="chip-row" id="player-chips"></div>
+      <section class="top-row">
+        <div class="prospects-panel panel">
+          <div id="mini-table" class="mini-table"></div>
+          <div id="radar" class="chart radar"></div>
+          <div class="stat-cards">
+            <div class="stat-card">
+              <div class="stat-title">PRODUCTION GRADE</div>
+              <div class="stat-value" id="stat-production"></div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-title">EFFICIENCY GRADE</div>
+              <div class="stat-value" id="stat-efficiency"></div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-title" id="stat-metric3-title"></div>
+              <div class="stat-value" id="stat-metric3"></div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-title">ATHLETICISM GRADE</div>
+              <div class="stat-value" id="stat-athleticism"></div>
+            </div>
+          </div>
+          <div id="sparkline" class="chart sparkline"></div>
+          <div class="nav-buttons">
+            <button id="prev">Previous</button>
+            <button id="next">Next</button>
+          </div>
+        </div>
+        <div class="analytics-panel panel">
+          <iframe id="embed-syop" class="embed" loading="lazy"></iframe>
+          <iframe id="embed-gauges" class="embed" loading="lazy"></iframe>
+        </div>
+      </section>
+      <section class="middle-grid">
+        <iframe id="embed-ownership" class="embed panel" loading="lazy"></iframe>
+        <iframe id="embed-top60" class="embed panel" loading="lazy"></iframe>
+        <iframe id="embed-flex" class="embed panel" loading="lazy"></iframe>
+        <iframe id="embed-ppr" class="embed panel" loading="lazy"></iframe>
+      </section>
+      <section class="bottom-embed panel">
+        <iframe id="embed-hit-rate" class="embed" loading="lazy"></iframe>
+      </section>
+    </main>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/dynastyhub-home-rebuild/code/styles.css
+++ b/dynastyhub-home-rebuild/code/styles.css
@@ -1,0 +1,197 @@
+:root {
+  --color-canvas: #141a32;
+  --color-surface: #1a1e35;
+  --color-surface-secondary: #2c334f;
+  --color-text: #efefef;
+  --color-muted: #b7bddc;
+  --color-accent: #7300ff;
+  --color-info: #6bb0ff;
+  --color-success: #6affd0;
+  --color-danger: #ff0266;
+  --radius-panel: 12px;
+  --radius-chip: 14px;
+  --radius-button: 18px;
+  --font-heading: 'Orbitron', sans-serif;
+  --font-display: 'Bruno Ace', sans-serif;
+  --font-mono: 'Syncopate', sans-serif;
+  --font-body: 'DM Sans', 'Quicksand', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--color-canvas);
+  color: var(--color-text);
+  font-family: var(--font-body);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--color-surface);
+  padding: 1rem;
+}
+
+.header {
+  background: var(--color-surface);
+  padding: 1rem;
+  font-family: var(--font-heading);
+}
+
+.chip-row {
+  background: var(--color-surface-secondary);
+  padding: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  background: var(--color-surface);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-chip);
+  padding: 0.25rem 0.75rem;
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+.chip.active {
+  background: var(--color-accent);
+}
+
+.top-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-panel);
+  padding: 1rem;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+}
+
+.mini-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mini-table td {
+  padding: 0.25rem;
+  text-align: center;
+}
+
+.stat-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.stat-card {
+  background: var(--color-surface-secondary);
+  border-radius: var(--radius-panel);
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.stat-title {
+  font-family: var(--font-display);
+  font-size: 0.8rem;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  color: var(--color-success);
+}
+
+.chart {
+  width: 100%;
+}
+
+.radar {
+  height: 300px;
+}
+
+.sparkline {
+  height: 120px;
+  margin-top: 1rem;
+}
+
+.nav-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+}
+
+button {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-button);
+  padding: 0.4rem 1rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+button:hover {
+  filter: brightness(1.2);
+}
+
+.analytics-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.analytics-panel .embed {
+  flex: 1;
+  min-height: 200px;
+}
+
+.middle-grid {
+  padding: 1rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: repeat(2, 300px);
+  gap: 1rem;
+}
+
+.embed {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: var(--radius-panel);
+}
+
+.bottom-embed {
+  padding: 1rem;
+}
+
+.bottom-embed .embed {
+  height: 400px;
+}
+
+@media (max-width: 1200px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .top-row {
+    grid-template-columns: 1fr;
+  }
+  .middle-grid {
+    grid-template-columns: 1fr;
+    grid-template-rows: repeat(4, 300px);
+  }
+}


### PR DESCRIPTION
## Summary
- build static index.html, app.js, styles.css for client-only home page
- implement interactive player chips updating table, charts, stats
- embed external analytics charts via iframes

## Testing
- `npm test` (fails: ENOENT: no such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68bf05f73044832eac7a5050cee494f6